### PR TITLE
Update smithery manifest for local launch

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,1 +1,9 @@
 runtime: "python"
+remote: false
+entrypoint:
+  command: "mcp-discord"
+  args: []
+env:
+  DISCORD_TOKEN:
+    description: "Discord bot token used to authenticate the bot connection."
+    required: true


### PR DESCRIPTION
## Summary
- set the smithery manifest to advertise a local server by specifying `remote: false`
- document how to launch the server via the `mcp-discord` entry point and require the Discord token environment variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3225bf294832f9f149c299723181d