### PR TITLE
Remove interactive Discord token prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ uv venv
 uv pip install -e .
 ```
 
-3. Configure Claude Desktop (`%APPDATA%\Claude\claude_desktop_config.json` on Windows, `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS) so it runs the installed entry point via `uv`:
+3. Configure Claude Desktop (`%APPDATA%\Claude\claude_desktop_config.json` on Windows, `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS) so it runs the installed entry point via `uv`. Provide your Discord token using either the MCP session configuration or the `DISCORD_TOKEN` environment variable:
 ```json
     "discord": {
       "command": "uv",
@@ -67,15 +67,21 @@ uv pip install -e .
         "run",
         "mcp-discord"
       ],
-      "env": {
-        "DISCORD_TOKEN": "your_bot_token"
+      "session_config": {
+        "discordToken": "your_bot_token"
       }
     }
 ```
 
+   Alternatively, export the token before starting Claude Desktop and omit the `session_config` block:
+
+```bash
+export DISCORD_TOKEN=your_bot_token
+```
+
 ### Installing via Smithery
 
-To install Discord Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@wowjinxy/mcp-discord-manager):
+To install Discord Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@wowjinxy/mcp-discord-manager), ensure you supply the Discord token through your MCP client configuration (for example by setting `discordToken` in the session config) or by exporting `DISCORD_TOKEN` before starting the client:
 
 ```bash
 npx -y @smithery/cli install @wowjinxy/mcp-discord-manager --client claude

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,4 +6,4 @@ entrypoint:
 env:
   DISCORD_TOKEN:
     description: "Discord bot token used to authenticate the bot connection."
-    required: true
+    required: false


### PR DESCRIPTION
## Summary
- mark the DISCORD_TOKEN environment entry as optional so Smithery no longer prompts
- document how to provide the Discord token via session configuration or the DISCORD_TOKEN environment variable

## Testing
- uv run python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d32c6b04a8832fadd56fc4329336c0