### PR TITLE
Allow environment fallback for Discord token

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -5,5 +5,5 @@ entrypoint:
   args: []
 env:
   DISCORD_TOKEN:
-    description: "Discord bot token used to authenticate the bot connection."
+    description: "Discord bot token used to authenticate the bot connection when session config omits discordToken."
     required: false

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import pytest
+
+from discord_mcp.server import ConfigSchema, DiscordToolError, _get_session_config
+
+
+def _make_ctx(value):
+    return SimpleNamespace(session_config=value)
+
+
+def test_config_schema_allows_missing_token():
+    config = ConfigSchema.model_validate({})
+    assert config.discord_token is None
+    assert config.default_guild_id is None
+
+
+def test_initialize_allows_env_token(monkeypatch):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+    monkeypatch.setenv("DISCORD_TOKEN", " env-token ")
+
+    validated = ConfigSchema.model_validate({})
+    resolved = _get_session_config(_make_ctx(validated))
+
+    assert resolved.discord_token == "env-token"
+
+
+def test_get_session_config_prefers_explicit_token(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "env-token")
+    monkeypatch.setenv("DISCORD_DEFAULT_GUILD_ID", "987654")
+
+    resolved = _get_session_config(
+        _make_ctx({"discordToken": " session-token ", "defaultGuildId": 42})
+    )
+
+    assert resolved.discord_token == "session-token"
+    assert resolved.default_guild_id == 42
+
+
+def test_get_session_config_uses_env_default(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "env-token")
+    monkeypatch.setenv("DISCORD_DEFAULT_GUILD_ID", "12345")
+
+    resolved = _get_session_config(_make_ctx({}))
+
+    assert resolved.discord_token == "env-token"
+    assert resolved.default_guild_id == 12345
+
+
+def test_get_session_config_requires_token(monkeypatch):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+
+    with pytest.raises(DiscordToolError):
+        _get_session_config(_make_ctx({}))


### PR DESCRIPTION
## Summary
- make the Discord token session field optional and resolve it via `_normalize_token`, `_get_session_config`, and `_acquire`, falling back to `DISCORD_TOKEN` before raising an error while updating the Smithery instructions string
- clarify the `DISCORD_TOKEN` metadata description and add regression tests that cover environment fallback, explicit tokens, and missing-token failures

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d34769b2d0832f8d99626a716c5ec8