### PR TITLE
Allow extra session config fields

### DIFF
--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -38,7 +38,7 @@ class ConfigSchema(BaseModel):
         description="Optional default Discord server (guild) ID used when a tool call omits server_id.",
     )
 
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
 
 class DiscordToolError(RuntimeError):

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -15,6 +15,18 @@ def test_config_schema_allows_missing_token():
     assert config.default_guild_id is None
 
 
+def test_config_schema_ignores_extra_fields():
+    config = ConfigSchema.model_validate({
+        "discordToken": " token ",
+        "defaultGuildId": 123,
+        "unexpected": "value",
+    })
+
+    assert config.discord_token == " token "
+    assert config.default_guild_id == 123
+    assert not hasattr(config, "unexpected")
+
+
 def test_initialize_allows_env_token(monkeypatch):
     monkeypatch.delenv("DISCORD_TOKEN", raising=False)
     monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)


### PR DESCRIPTION
## Summary
- update the Discord MCP config schema to ignore unknown session parameters so Smithery scans no longer fail
- add regression coverage ensuring extra configuration keys are discarded while preserving known values

## Testing
- PYTHONPATH=src uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3624eaf50832fa9e23d40c329bff7