### PR TITLE
Normalize Discord token handling

### DIFF
--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -170,6 +170,19 @@ def _normalize_token(token: str | None) -> str | None:
     if token is None:
         return None
     stripped = token.strip()
+    if not stripped:
+        return None
+
+    if (stripped.startswith("\"") and stripped.endswith("\"")) or (
+        stripped.startswith("'") and stripped.endswith("'")
+    ):
+        stripped = stripped[1:-1].strip()
+        if not stripped:
+            return None
+
+    if stripped.lower().startswith("bot "):
+        stripped = stripped[4:].strip()
+
     return stripped or None
 
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -66,3 +66,23 @@ def test_get_session_config_requires_token(monkeypatch):
 
     with pytest.raises(DiscordToolError):
         _get_session_config(_make_ctx({}))
+
+
+def test_get_session_config_strips_bot_prefix(monkeypatch):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+
+    resolved = _get_session_config(_make_ctx({"discordToken": " Bot session-token"}))
+
+    assert resolved.discord_token == "session-token"
+
+
+def test_get_session_config_strips_quotes(monkeypatch):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+
+    resolved = _get_session_config(
+        _make_ctx({"discordToken": ' "quoted-session-token" '})
+    )
+
+    assert resolved.discord_token == "quoted-session-token"


### PR DESCRIPTION
## Summary
- normalize Discord bot tokens by trimming optional quotes and `Bot ` prefixes
- add configuration tests covering the new normalization cases

## Testing
- PYTHONPATH=src uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36a56b3ec832fb974a52b0809e41f