### PR TITLE
Normalize invalid discord tokens before use

### DIFF
--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -182,6 +182,11 @@ def _normalize_token(token: str | None) -> str | None:
 
     if stripped.lower().startswith("bot "):
         stripped = stripped[4:].strip()
+        if not stripped:
+            return None
+
+    if any(ch.isspace() for ch in stripped):
+        return None
 
     return stripped or None
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -86,3 +86,22 @@ def test_get_session_config_strips_quotes(monkeypatch):
     )
 
     assert resolved.discord_token == "quoted-session-token"
+
+
+def test_get_session_config_ignores_tokens_with_whitespace(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "env-token")
+    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+
+    resolved = _get_session_config(
+        _make_ctx({"discordToken": " invalid token contents "})
+    )
+
+    assert resolved.discord_token == "env-token"
+
+
+def test_get_session_config_rejects_invalid_tokens(monkeypatch):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+
+    with pytest.raises(DiscordToolError):
+        _get_session_config(_make_ctx({"discordToken": "not a real token"}))


### PR DESCRIPTION
## Summary
- treat whitespace-only or bot-prefixed tokens that become empty as missing
- ignore session tokens containing internal whitespace so environment tokens can be used instead
- add coverage for whitespace token handling in `_get_session_config`

## Testing
- PYTHONPATH=src pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d37123ce88832f944ad3d89342bd8b