### PR TITLE
Support discordToken environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ uv venv
 uv pip install -e .
 ```
 
-3. Configure Claude Desktop (`%APPDATA%\Claude\claude_desktop_config.json` on Windows, `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS) so it runs the installed entry point via `uv`. Provide your Discord token using either the MCP session configuration or the `DISCORD_TOKEN` environment variable:
+3. Configure Claude Desktop (`%APPDATA%\Claude\claude_desktop_config.json` on Windows, `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS) so it runs the installed entry point via `uv`. Provide your Discord token using either the MCP session configuration or the `DISCORD_TOKEN`/`discordToken` environment variable:
 ```json
     "discord": {
       "command": "uv",
@@ -77,11 +77,13 @@ uv pip install -e .
 
 ```bash
 export DISCORD_TOKEN=your_bot_token
+## or use the camelCase environment name supported by some clients
+export discordToken=your_bot_token
 ```
 
 ### Installing via Smithery
 
-To install Discord Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@wowjinxy/mcp-discord-manager), ensure you supply the Discord token through your MCP client configuration (for example by setting `discordToken` in the session config) or by exporting `DISCORD_TOKEN` before starting the client:
+To install Discord Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@wowjinxy/mcp-discord-manager), ensure you supply the Discord token through your MCP client configuration (for example by setting `discordToken` in the session config) or by exporting `DISCORD_TOKEN`/`discordToken` before starting the client:
 
 ```bash
 npx -y @smithery/cli install @wowjinxy/mcp-discord-manager --client claude

--- a/src/discord_mcp/integrated_server.py
+++ b/src/discord_mcp/integrated_server.py
@@ -36,9 +36,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("discord-mcp-server")
 
 # Discord bot setup
-DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN") or os.getenv("discordToken")
 if not DISCORD_TOKEN:
-    raise ValueError("DISCORD_TOKEN environment variable is required")
+    raise ValueError("DISCORD_TOKEN or discordToken environment variable is required")
 
 # Initialize Discord bot with necessary intents
 intents = discord.Intents.default()

--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -46,7 +46,8 @@ class DiscordToolError(RuntimeError):
 
 
 _MISSING_TOKEN_MESSAGE = (
-    "No Discord token provided. Configure a token via Smithery session config or the DISCORD_TOKEN environment variable."
+    "No Discord token provided. Configure a token via Smithery session config or the DISCORD_TOKEN/discordToken environment "
+    "variable."
 )
 
 
@@ -192,8 +193,24 @@ def _normalize_token(token: str | None) -> str | None:
 
 
 def _get_env_config() -> ConfigSchema:
-    token = _normalize_token(os.getenv("DISCORD_TOKEN"))
-    guild_raw = os.getenv("DISCORD_DEFAULT_GUILD_ID")
+    token: str | None = None
+    for env_name in ("DISCORD_TOKEN", "discordToken"):
+        candidate = _normalize_token(os.getenv(env_name))
+        if candidate is not None:
+            token = candidate
+            break
+
+    guild_raw: str | None = None
+    for env_name in ("DISCORD_DEFAULT_GUILD_ID", "discordDefaultGuildId", "defaultGuildId"):
+        value = os.getenv(env_name)
+        if value is None:
+            continue
+        stripped = value.strip()
+        if not stripped:
+            continue
+        guild_raw = stripped
+        break
+
     default_guild = int(guild_raw) if guild_raw else None
     return ConfigSchema(discord_token=token, default_guild_id=default_guild)
 
@@ -359,8 +376,8 @@ def create_server() -> FastMCP:
     server = FastMCP(
         name="Discord Server",
         instructions=(
-            "Interact with Discord using a bot token. Configure `discordToken` (or set the `DISCORD_TOKEN` environment "
-            "variable) and an optional `defaultGuildId` when connecting through Smithery."
+            "Interact with Discord using a bot token. Configure `discordToken` (or set the `DISCORD_TOKEN` or "
+            "`discordToken` environment variable) and an optional `defaultGuildId` when connecting through Smithery."
         ),
         lifespan=lifespan,
     )

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -9,6 +9,20 @@ def _make_ctx(value):
     return SimpleNamespace(session_config=value)
 
 
+_TOKEN_ENV_VARS = ("DISCORD_TOKEN", "discordToken")
+_GUILD_ENV_VARS = ("DISCORD_DEFAULT_GUILD_ID", "discordDefaultGuildId", "defaultGuildId")
+
+
+def _clear_token_env(monkeypatch):
+    for name in _TOKEN_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _clear_guild_env(monkeypatch):
+    for name in _GUILD_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
 def test_config_schema_allows_missing_token():
     config = ConfigSchema.model_validate({})
     assert config.discord_token is None
@@ -28,8 +42,8 @@ def test_config_schema_ignores_extra_fields():
 
 
 def test_initialize_allows_env_token(monkeypatch):
-    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
-    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
     monkeypatch.setenv("DISCORD_TOKEN", " env-token ")
 
     validated = ConfigSchema.model_validate({})
@@ -38,7 +52,31 @@ def test_initialize_allows_env_token(monkeypatch):
     assert resolved.discord_token == "env-token"
 
 
+def test_initialize_allows_env_token_alias(monkeypatch):
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
+    monkeypatch.setenv("discordToken", " env-token ")
+
+    validated = ConfigSchema.model_validate({})
+    resolved = _get_session_config(_make_ctx(validated))
+
+    assert resolved.discord_token == "env-token"
+
+
+def test_env_token_alias_used_when_primary_blank(monkeypatch):
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
+    monkeypatch.setenv("DISCORD_TOKEN", "   ")
+    monkeypatch.setenv("discordToken", "env-token")
+
+    resolved = _get_session_config(_make_ctx({}))
+
+    assert resolved.discord_token == "env-token"
+
+
 def test_get_session_config_prefers_explicit_token(monkeypatch):
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
     monkeypatch.setenv("DISCORD_TOKEN", "env-token")
     monkeypatch.setenv("DISCORD_DEFAULT_GUILD_ID", "987654")
 
@@ -51,6 +89,8 @@ def test_get_session_config_prefers_explicit_token(monkeypatch):
 
 
 def test_get_session_config_uses_env_default(monkeypatch):
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
     monkeypatch.setenv("DISCORD_TOKEN", "env-token")
     monkeypatch.setenv("DISCORD_DEFAULT_GUILD_ID", "12345")
 
@@ -60,17 +100,29 @@ def test_get_session_config_uses_env_default(monkeypatch):
     assert resolved.default_guild_id == 12345
 
 
+def test_get_session_config_uses_env_default_alias(monkeypatch):
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
+    monkeypatch.setenv("discordToken", "env-token")
+    monkeypatch.setenv("discordDefaultGuildId", "54321")
+
+    resolved = _get_session_config(_make_ctx({}))
+
+    assert resolved.discord_token == "env-token"
+    assert resolved.default_guild_id == 54321
+
+
 def test_get_session_config_requires_token(monkeypatch):
-    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
-    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
 
     with pytest.raises(DiscordToolError):
         _get_session_config(_make_ctx({}))
 
 
 def test_get_session_config_strips_bot_prefix(monkeypatch):
-    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
-    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
 
     resolved = _get_session_config(_make_ctx({"discordToken": " Bot session-token"}))
 
@@ -78,8 +130,8 @@ def test_get_session_config_strips_bot_prefix(monkeypatch):
 
 
 def test_get_session_config_strips_quotes(monkeypatch):
-    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
-    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
 
     resolved = _get_session_config(
         _make_ctx({"discordToken": ' "quoted-session-token" '})
@@ -89,8 +141,9 @@ def test_get_session_config_strips_quotes(monkeypatch):
 
 
 def test_get_session_config_ignores_tokens_with_whitespace(monkeypatch):
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
     monkeypatch.setenv("DISCORD_TOKEN", "env-token")
-    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
 
     resolved = _get_session_config(
         _make_ctx({"discordToken": " invalid token contents "})
@@ -100,8 +153,8 @@ def test_get_session_config_ignores_tokens_with_whitespace(monkeypatch):
 
 
 def test_get_session_config_rejects_invalid_tokens(monkeypatch):
-    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
-    monkeypatch.delenv("DISCORD_DEFAULT_GUILD_ID", raising=False)
+    _clear_token_env(monkeypatch)
+    _clear_guild_env(monkeypatch)
 
     with pytest.raises(DiscordToolError):
         _get_session_config(_make_ctx({"discordToken": "not a real token"}))


### PR DESCRIPTION
## Summary
- allow the FastMCP server to resolve Discord credentials from the `discordToken` environment variable in addition to `DISCORD_TOKEN`
- update the integrated server and documentation to reflect the new environment variable option
- expand configuration tests to cover the new environment variable handling

## Testing
- PYTHONPATH=src uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d378e88bc4832f9d6e15b89e12eaf9