### PR TITLE
Expand Discord management tool coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ A Model Context Protocol (MCP) server that provides Discord integration capabili
 - `list_servers`: List available servers
 - `get_server_info`: Get detailed server information
 - `get_channels`: List channels in a server
+- `list_roles`: View all roles in a server
 - `list_members`: List server members and their roles
+- `list_invites`: Display active invite links
+- `list_bans`: Show banned users
 - `get_user_info`: Get detailed information about a user
 
 ### Message Management
@@ -20,15 +23,32 @@ A Model Context Protocol (MCP) server that provides Discord integration capabili
 - `add_reaction`: Add a reaction to a message
 - `add_multiple_reactions`: Add multiple reactions to a message
 - `remove_reaction`: Remove a reaction from a message
+- `pin_message`: Pin a message in a channel
+- `unpin_message`: Unpin a pinned message
+- `bulk_delete_messages`: Remove batches of recent messages
 - `moderate_message`: Delete messages and timeout users
 
 ### Channel Management
 - `create_text_channel`: Create a new text channel
+- `create_voice_channel`: Create a new voice channel
+- `create_stage_channel`: Create a stage channel for events
+- `create_category`: Create a channel category
+- `update_channel`: Modify channel settings
 - `delete_channel`: Delete an existing channel
+- `create_invite`: Generate invite links for channels
 
 ### Role Management
+- `create_role`: Create new roles
+- `edit_role`: Update existing roles
+- `delete_role`: Remove roles
 - `add_role`: Add a role to a user
 - `remove_role`: Remove a role from a user
+
+### Member Management
+- `kick_member`: Remove a member from the server
+- `ban_member`: Ban a member and optionally delete recent messages
+- `unban_member`: Lift a ban for a user
+- `timeout_member`: Apply or clear communication timeouts
 
 ## Installation
 

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -1,0 +1,80 @@
+import pytest
+
+from discord_mcp.server import (
+    DiscordToolError,
+    _parse_colour,
+    _parse_optional_bool,
+    _parse_permissions,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("NO", False),
+        (1, True),
+        (0, False),
+        (None, None),
+    ],
+)
+def test_parse_optional_bool_valid(value, expected):
+    assert _parse_optional_bool(value, "test") == expected
+
+
+@pytest.mark.parametrize("value", ["maybe", 2, object()])
+def test_parse_optional_bool_invalid(value):
+    with pytest.raises(DiscordToolError):
+        _parse_optional_bool(value, "test")
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("#FF0000", 0xFF0000),
+        ("0x00ff00", 0x00FF00),
+        ("default", 0x000000),
+        (16711935, 0xFF00FF),
+    ],
+)
+def test_parse_colour_valid(value, expected):
+    colour = _parse_colour(value, name="color")
+    assert colour is not None
+    assert colour.value == expected
+
+
+def test_parse_colour_named():
+    colour = _parse_colour("blurple", name="color")
+    assert colour is not None
+    # discord.py's blurple constant is 0x5865F2
+    assert colour.value == 0x5865F2
+
+
+@pytest.mark.parametrize("value", ["not-a-colour", -1])
+def test_parse_colour_invalid(value):
+    with pytest.raises(DiscordToolError):
+        _parse_colour(value, name="color")
+
+
+def test_parse_permissions_from_list():
+    perms = _parse_permissions(["manage_roles", "kick_members"], None)
+    assert perms is not None
+    assert perms.manage_roles and perms.kick_members
+    assert not perms.administrator
+
+
+def test_parse_permissions_from_value():
+    perms = _parse_permissions(None, "1049600")
+    assert perms is not None
+    assert isinstance(perms.value, int)
+
+
+def test_parse_permissions_unknown_name():
+    with pytest.raises(DiscordToolError):
+        _parse_permissions(["not_a_permission"], None)
+
+
+def test_parse_permissions_none():
+    assert _parse_permissions(None, None) is None


### PR DESCRIPTION
## Summary
- add utility helpers and broaden the MCP server toolset to cover invites, roles, channels, member moderation, and message pinning/bulk deletion
- update README tool list to describe the expanded capabilities
- add unit tests for new helper parsers

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d381578fa8832f966a3d80e27f2348