### PR TITLE
Normalize permission alias handling

### DIFF
--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -396,6 +396,11 @@ def _parse_colour(value: str | int | None, *, name: str = "colour") -> discord.C
     raise DiscordToolError(f"{name} must be specified as a hex string or integer value.")
 
 
+_PERMISSION_ALIASES: dict[str, str] = {
+    "admin": "administrator",
+}
+
+
 def _parse_permissions(
     permissions: Sequence[str] | None,
     permissions_value: str | int | None,
@@ -415,6 +420,10 @@ def _parse_permissions(
     perms = discord.Permissions.none()
     for entry in permissions:
         normalized = str(entry).strip().lower()
+        if not normalized:
+            continue
+        normalized = normalized.replace(" ", "_").replace("-", "_")
+        normalized = _PERMISSION_ALIASES.get(normalized, normalized)
         if not normalized:
             continue
         if not hasattr(discord.Permissions, normalized):

--- a/src/discord_mcp/utils.py
+++ b/src/discord_mcp/utils.py
@@ -17,6 +17,7 @@ def parse_permissions(permission_list: List[str]) -> discord.Permissions:
     # Map common permission names to discord.py attributes
     permission_mapping = {
         "administrator": "administrator",
+        "admin": "administrator",
         "manage_server": "manage_guild",
         "manage_guild": "manage_guild",
         "manage_channels": "manage_channels",
@@ -63,7 +64,7 @@ def parse_permissions(permission_list: List[str]) -> discord.Permissions:
     
     for perm in permission_list:
         # Convert to lowercase and handle variations
-        perm_lower = perm.lower().replace(" ", "_")
+        perm_lower = perm.lower().replace(" ", "_").replace("-", "_")
         
         # Map the permission
         discord_perm = permission_mapping.get(perm_lower, perm_lower)

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -6,6 +6,7 @@ from discord_mcp.server import (
     _parse_optional_bool,
     _parse_permissions,
 )
+from discord_mcp.utils import parse_permissions
 
 
 @pytest.mark.parametrize(
@@ -65,6 +66,14 @@ def test_parse_permissions_from_list():
     assert not perms.administrator
 
 
+def test_parse_permissions_accepts_common_aliases():
+    perms = _parse_permissions(["Admin", "Manage Channels", "manage-roles"], None)
+    assert perms is not None
+    assert perms.administrator
+    assert perms.manage_channels
+    assert perms.manage_roles
+
+
 def test_parse_permissions_from_value():
     perms = _parse_permissions(None, "1049600")
     assert perms is not None
@@ -78,3 +87,8 @@ def test_parse_permissions_unknown_name():
 
 def test_parse_permissions_none():
     assert _parse_permissions(None, None) is None
+
+
+def test_utils_parse_permissions_alias():
+    perms = parse_permissions(["Admin"])
+    assert perms.administrator


### PR DESCRIPTION
## Summary
- normalize permission names in the FastMCP server so entries like "Admin" and spaced names are accepted
- add the same alias handling to the shared permission parser utility
- cover the new behaviour with unit tests for both parsers

## Testing
- PYTHONPATH=src uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3884eb908832f973368f1798e294d