### PR TITLE
Use uv runtime base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
-FROM python:3.12-slim-bookworm
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 # Create a non-root user that will own the application files.
 RUN groupadd --system app \


### PR DESCRIPTION
## Summary
- switch the runtime stage of the Dockerfile to use the same uv-hosted Python image as the build stage to avoid unauthenticated Docker Hub pulls

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'discord_mcp')*

------
https://chatgpt.com/codex/tasks/task_e_68d4900a8364832fab323925200ea370