### PR TITLE
Configure pytest pythonpath for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ playground = "smithery.cli.playground:main"
 
 [tool.smithery]
 server = "discord_mcp.server:create_server"
+
+[tool.pytest.ini_options]
+pythonpath = [
+    "src",
+]


### PR DESCRIPTION
## Summary
- configure pytest to add the src directory to Python path so the package imports resolve during tests

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4976fb1d0832f99b688ff2df26b8c